### PR TITLE
Compare headers in same case

### DIFF
--- a/Sources/Request.swift
+++ b/Sources/Request.swift
@@ -28,7 +28,7 @@ public struct Request : RequestType, CustomStringConvertible, CustomDebugStringC
 extension RequestType {
   public subscript(header: String) -> String? {
     get {
-      return headers.filter { $0.0 == header }.first?.1
+      return headers.filter { $0.0.lowercaseString == header.lowercaseString }.first?.1
     }
   }
 


### PR DESCRIPTION
Check out this webhook from GitHub and note the case of `content-type`

```
Request URL: http://318ed8a6.ngrok.io/handler
Request method: POST
content-type: application/json
Expect: 
User-Agent: GitHub-Hookshot/35ff2c9
X-GitHub-Delivery: 79a30d80-ae6f-11e5-875b-a6c62a2c4416
X-GitHub-Event: pull_request
```
