### PR TITLE
public

### DIFF
--- a/Sources/Payload.swift
+++ b/Sources/Payload.swift
@@ -6,14 +6,14 @@ public protocol PayloadConvertible {
 }
 
 
-class BytesPayload : PayloadType {
-  var bytes: [Int8]
+public final class BytesPayload : PayloadType {
+  public var bytes: [Int8]
 
-  init(bytes: [Int8]) {
+  public init(bytes: [Int8]) {
     self.bytes = bytes
   }
 
-  func next() -> Int8? {
+  public func next() -> Int8? {
     if bytes.isEmpty {
       return nil
     }

--- a/Sources/Payload.swift
+++ b/Sources/Payload.swift
@@ -1,0 +1,34 @@
+import Nest
+
+
+public protocol PayloadConvertible {
+  func toPayload() -> PayloadType
+}
+
+
+class BytesPayload : PayloadType {
+  var bytes: [Int8]
+
+  init(bytes: [Int8]) {
+    self.bytes = bytes
+  }
+
+  func next() -> Int8? {
+    if bytes.isEmpty {
+      return nil
+    }
+
+    return bytes.removeFirst()
+  }
+}
+
+
+extension String : PayloadConvertible {
+  var bytes: [Int8] {
+    return utf8.map { Int8($0) }
+  }
+
+  public func toPayload() -> PayloadType {
+    return BytesPayload(bytes: bytes)
+  }
+}

--- a/Sources/Request.swift
+++ b/Sources/Request.swift
@@ -5,13 +5,16 @@ public struct Request : RequestType, CustomStringConvertible, CustomDebugStringC
   public var method:String
   public var path:String
   public var headers:[Header]
-  public var body:String?
+  public var content: PayloadConvertible?
+  public var body: PayloadType? {
+    return content?.toPayload()
+  }
 
-  public init(method:String, path:String, headers:[Header]? = nil, body:String? = nil) {
+  public init(method:String, path:String, headers:[Header]? = nil, content: PayloadConvertible? = nil) {
     self.method = method
     self.path = path
     self.headers = headers ?? []
-    self.body = body
+    self.content = content
   }
 
   public var description:String {

--- a/Sources/Response.swift
+++ b/Sources/Response.swift
@@ -4,12 +4,15 @@ import Nest
 public struct Response : ResponseType {
   public var status:Status
   public var headers:[Header]
-  public var body:String?
+  public var content: PayloadConvertible?
+  public var body: PayloadType? {
+    return content?.toPayload()
+  }
 
-  public init(_ status:Status, headers:[Header]? = nil, contentType:String? = nil, body:String? = nil) {
+  public init(_ status:Status, headers:[Header]? = nil, contentType:String? = nil, content: PayloadConvertible? = nil) {
     self.status = status
     self.headers = headers ?? []
-    self.body = body
+    self.content = content
 
     if let contentType = contentType {
       self.headers.append(("Content-Type", contentType))

--- a/Specs/PayloadSpec.swift
+++ b/Specs/PayloadSpec.swift
@@ -1,0 +1,13 @@
+import Spectre
+import Nest
+import Inquiline
+
+
+describe("String Payload Conformance") {
+  $0.it("can read a strings bytes") {
+    var content = "Hello World".toPayload()
+
+    try equal(content.next(), Int8(72))
+    try equal(content.next(), Int8(101))
+  }
+}


### PR DESCRIPTION
I think the `BytesPayload` object is useful as a public asset for quickly declaring `PayloadConvertible` types.
